### PR TITLE
fix(navigator/rtl): prevent VTOL MC-state stall by redirecting to RTL_DIRECT

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This fork adds airframes and board configurations required for operating the UAS
 
   Default board config for FSR.
 
+### `boards/cubepilot/cubeorangeplus`
+
+- [crsf.px4board](boards/cubepilot/cubeorangeplus/crsf.px4board)
+
+  Crsf board config.
+
 ## Additional Airframes
 
 ### `ROMFS/px4fmu_common/init.d/airframes`
@@ -21,3 +27,15 @@ This fork adds airframes and board configurations required for operating the UAS
 - [13001_tuda_fsr_scidragon](ROMFS/px4fmu_common/init.d/airframes/13001_tuda_fsr_scidragon)
 
 ### `ROMFS/px4fmu_common/init.d-posix/airframes` (Simulation)
+
+## Code Changes
+
+**`rtl_direct_mission_land.cpp`**
+Temporarily disables the transition-to-fixed-wing block to prevent a state
+transition attempt with uninitialized mission data.
+
+**`rtl.cpp` — `setRtlTypeAndDestination()`**
+Adds a vehicle state check before the RTL type is assigned. If the airframe
+is a VTOL and the current vehicle state is rotary-wing (MC), the RTL type is
+overridden from `RTL_DIRECT_MISSION_LAND` to `RTL_DIRECT`, sending the vehicle
+directly to home position. This only applies, if  `RTL_TYPE!=0`

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -324,8 +324,26 @@ void RTL::setRtlTypeAndDestination()
 
 		switch (destination_type) {
 		case DestinationType::DESTINATION_TYPE_MISSION_LAND:
-			_rtl_type = RtlType::RTL_DIRECT_MISSION_LAND;
-			_rtl_mission_type_handle->setRtlAlt(rtl_alt);
+			// Fix: VTOL in MC-State goes directly into direct RTL
+			// (instead of flying the FW landing pattern as a MC)
+			// VTOL in FW and pure MC keeping the intended RTL_DIRECT_MISSION_LAND
+			if (_vehicle_status_sub.get().is_vtol
+				&& _vehicle_status_sub.get().vehicle_type
+				== vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+
+				loiter_point_s landing_loiter;
+				landing_loiter.lat = rtl_position.lat;
+				landing_loiter.lon = rtl_position.lon;
+				landing_loiter.height_m = NAN;
+
+				_rtl_type = RtlType::RTL_DIRECT;
+				_rtl_direct.setRtlAlt(rtl_alt);
+				_rtl_direct.setRtlPosition(rtl_position, landing_loiter);
+
+			} else {
+				_rtl_type = RtlType::RTL_DIRECT_MISSION_LAND;
+				_rtl_mission_type_handle->setRtlAlt(rtl_alt);
+			}
 			break;
 
 		case DestinationType::DESTINATION_TYPE_SAFE_POINT: // Fallthrough

--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -155,7 +155,11 @@ void RtlDirectMissionLand::setActiveMissionItems()
 
 		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_CLIMB;
 
-	} else if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
+	}
+	// Disabled temporarily: the transition-to-fixed-wing path uses mission data
+	// before it is initialized correctly in this execution path.
+
+	/*else if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
 		   _vehicle_status_sub.get().is_vtol &&
 		   !_land_detected_sub.get().landed && _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
 		// Transition to fixed wing if necessary.
@@ -167,7 +171,8 @@ void RtlDirectMissionLand::setActiveMissionItems()
 
 		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
 
-	} else if (item_contains_position(_mission_item)) {
+	} */
+	 else if (item_contains_position(_mission_item)) {
 
 		static constexpr size_t max_num_next_items{1u};
 		int32_t next_mission_items_index[max_num_next_items];


### PR DESCRIPTION
## Solved Problem

When RTL is triggered with `RTL_TYPE != 0`, a VTOL aircraft in multicopter (MC) state does not proceed after reaching RTL altitude. The vehicle stalls mid-air instead of continuing toward the landing destination.

The root cause is the transition-to-fixed-wing block in `rtl_direct_mission_land.cpp`, which accesses mission data before it is correctly initialized in this execution path.

## Solution
**`rtl_direct_mission_land.cpp`**
Temporarily disables the transition-to-fixed-wing block to prevent a state transition attempt with uninitialized mission data.

**`rtl.cpp` — `setRtlTypeAndDestination()`**
Adds a vehicle state check before the RTL type is assigned. If the airframe is a VTOL and the current vehicle state is rotary-wing (MC), the RTL type is overridden from `RTL_DIRECT_MISSION_LAND` to `RTL_DIRECT`, sending the vehicle directly to the nearest safe destination (mission land point, rally point, or home — whichever is closest).

### Affected Behavior by Vehicle Type

| Airframe | State | RTL Type | Behavior |
| :-- | :-- | :-- | :-- |
| VTOL | MC | `RTL_DIRECT` ← changed | Flies directly to nearest destination — safe |
| VTOL | Fixed Wing | `RTL_DIRECT_MISSION_LAND` | Normal mission landing pattern — unchanged |
| Pure MC (non-VTOL) | MC | `RTL_DIRECT_MISSION_LAND` | Unchanged — normal behavior |

### Affected Files

- `src/modules/navigator/rtl.cpp`
- `src/modules/navigator/rtl_direct_mission_land.cpp`

## Test coverage

Tested on VTOL airframe in simulation (Gazebo) with `RTL_TYPE = 1` (Mission Landing/Rally Point).


| \# | Vehicle State | Closest RTL Destination | Before Fix | After Fix | Result |
| :-- | :-- | :-- | :-- | :-- | :-- |
| 1 | MC | Mission Land Point | Stalls at RTL altitude, does not proceed | Redirected to `RTL_DIRECT` → flies to land point, lands as MC | Pass |
| 2 | MC | Home Point | Stalls at RTL altitude, does not proceed | Redirected to `RTL_DIRECT` → flies to home, lands as MC | Pass |
| 3 | Fixed Wing | Mission Land Point | Follows mission landing pattern normally | Unchanged — `RTL_DIRECT_MISSION_LAND` retained | Pass |
| 4 | Fixed Wing | Home Point | Transitions to MC at destination, lands normally | Unchanged — `RTL_DIRECT_MISSION_LAND` retained | Pass |
| 5 | MC (during transition MC→FW) | Mission Land Point | Finishes transition to FW, follows mission landing pattern | Unchanged — `RTL_DIRECT_MISSION_LAND` retained | Pass |
| 6 | MC (during transition MC→FW) | Home Point | Finishes transition to FW, follows mission landing pattern | Unchanged — `RTL_DIRECT_MISSION_LAND` retained | Pass |